### PR TITLE
python-pyqt5: Disable parallel install

### DIFF
--- a/recipes-python/pyqt5/python-pyqt5.inc
+++ b/recipes-python/pyqt5/python-pyqt5.inc
@@ -14,7 +14,7 @@ SRC_URI[sha256sum] = "c9b57d15601d436faf35dacf8e0acefa220194829a653e771e80b189b3
 
 S = "${WORKDIR}/PyQt5_gpl-${PV}"
 
-inherit qmake5
+inherit qmake5 python3native python3-dir
 DEPENDS = "qtbase"
 
 export BUILD_SYS
@@ -56,6 +56,8 @@ do_install() {
     cd ${S}
     oe_runmake install
 }
+
+PARALLEL_MAKEINST = ""
 
 FILES_${PN} += "${libdir}/${PYTHON_DIR}${PYTHON_ABI}/site-packages ${datadir}/sip/PyQt5/"
 

--- a/recipes-python/pyqt5/python-pyqt5_5.11.3.bb
+++ b/recipes-python/pyqt5/python-pyqt5_5.11.3.bb
@@ -1,8 +1,5 @@
 require python-pyqt5.inc
 
-inherit pythonnative python-dir
-
 DEPENDS += "sip sip-native python"
 
 RDEPENDS_${PN} += "python-core python-sip"
-

--- a/recipes-python/pyqt5/python3-pyqt5_5.11.3.bb
+++ b/recipes-python/pyqt5/python3-pyqt5_5.11.3.bb
@@ -1,7 +1,5 @@
 require python-pyqt5.inc
 
-inherit python3native python3-dir
-
 DEPENDS += "sip3 sip3-native python3"
 
 RDEPENDS_${PN} += "python3-core python3-sip3"


### PR DESCRIPTION
use python3native during build for both py3 and py2 versions as per
http://pyqt.sourceforge.net/Docs/PyQt5/installation.html

Avoid certain race during do_install

|   File
"/mnt/a/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/python-pyqt5/5.11.3-r0/PyQt5_gpl-5.11.3/mk_distinfo.py",
line 108, in <module>
|     fn_f = open(fn, 'rb')
| FileNotFoundError: [Errno 2] No such file or directory:
'/mnt/a/yoe/build/tmp/work/cortexa7t2hf-neon-vfpv4-yoe-linux-gnueabi/python-pyqt5/5.11.3-r0/image//usr/lib/python2.7/site-packages/PyQt5/QtCore.so'

Signed-off-by: Khem Raj <raj.khem@gmail.com>